### PR TITLE
Update vital-vs

### DIFF
--- a/autoload/vital/_fern_preview/VS/Vim/Buffer.vim
+++ b/autoload/vital/_fern_preview/VS/Vim/Buffer.vim
@@ -50,9 +50,8 @@ function! s:ensure(expr) abort
   if !bufexists(a:expr)
     if type(a:expr) == type(0)
       throw printf('VS.Vim.Buffer: `%s` is not valid expr.', l:bufnr)
-    else
-      badd `=a:expr`
     endif
+    badd `=a:expr`
   endif
   return bufnr(a:expr)
 endfunction

--- a/autoload/vital/_fern_preview/VS/Vim/Window.vim
+++ b/autoload/vital/_fern_preview/VS/Vim/Window.vim
@@ -19,7 +19,7 @@ function! s:do(winid, func) abort
     return
   endif
 
-  if exists('*win_execute')
+  if !has('nvim') && exists('*win_execute')
     let s:Do = a:func
     try
       noautocmd keepalt keepjumps call win_execute(a:winid, 'call s:Do()')

--- a/autoload/vital/_fern_preview/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_fern_preview/VS/Vim/Window/FloatingWindow.vim
@@ -304,7 +304,9 @@ else
       let a:self._on_closed = l:On_closed
       return s:_open(a:bufnr, a:style, { -> a:self._on_closed() })
     endif
-    call popup_move(a:winid, s:_style(a:style))
+    let l:style = s:_style(a:style)
+    call popup_move(a:winid, l:style)
+    call popup_setoptions(a:winid, l:style)
     return a:winid
   endfunction
 endif
@@ -478,12 +480,13 @@ endif
 " init
 "
 let s:has_init = v:false
+let s:filepath = expand('<sfile>:p')
 function! s:_init() abort
   if s:has_init || !has('nvim')
     return
   endif
   let s:has_init = v:true
-  augroup printf('VS_Vim_Window_FloatingWindow:%s', expand('<sfile>'))
+  execute printf('augroup VS_Vim_Window_FloatingWindow:%s', s:filepath)
     autocmd!
     autocmd WinEnter * call <SID>_notify_closed()
   augroup END


### PR DESCRIPTION
This PR aims to solve the wrong augroup definition.

The older implementation will create the augroup as `print(...)` but the newer implementation will create the correct augroup that uses filepath.