### PR TITLE
Fix unable to preview last two lines in vim

### DIFF
--- a/autoload/vital/_fern_preview/VS/Vim/Window.vim
+++ b/autoload/vital/_fern_preview/VS/Vim/Window.vim
@@ -57,7 +57,7 @@ else
       let l:info = popup_getpos(a:winid)
       return {
       \   'width': l:info.width,
-      \   'height': l:info.height,
+      \   'height': l:info.height - 2,
       \   'topline': l:info.firstline
       \ }
     endif


### PR DESCRIPTION
As borders are default enabled in this plugin in vim, the top and bottom borders will take up 2 lines. Then in https://github.com/yuki-yano/fern-preview.vim/blob/74f2c1c45eb48fe9b7e4aa87032f053808944e17/autoload/vital/_fern_preview/VS/Vim/Window.vim#L109, it can't preview the last 2 lines when scroll down to bottom in vim.